### PR TITLE
Category features

### DIFF
--- a/src/main/java/com/andresv2/apirest/auth/SecurityConfig.java
+++ b/src/main/java/com/andresv2/apirest/auth/SecurityConfig.java
@@ -3,7 +3,6 @@ package com.andresv2.apirest.auth;
 import com.andresv2.apirest.service.UserDetailService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;

--- a/src/main/java/com/andresv2/apirest/auth/UserAuthenticationEntryPoint.java
+++ b/src/main/java/com/andresv2/apirest/auth/UserAuthenticationEntryPoint.java
@@ -1,7 +1,6 @@
 package com.andresv2.apirest.auth;
 
 import com.andresv2.apirest.dto.ErrorResponseDto;
-import com.andresv2.apirest.exception.CustomExceptionHandler;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -14,7 +13,6 @@ import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
-import org.springframework.web.context.request.WebRequest;
 
 import java.io.IOException;
 

--- a/src/main/java/com/andresv2/apirest/controller/CategoryController.java
+++ b/src/main/java/com/andresv2/apirest/controller/CategoryController.java
@@ -1,0 +1,58 @@
+package com.andresv2.apirest.controller;
+
+import com.andresv2.apirest.entities.Category;
+import com.andresv2.apirest.repository.ProductRepository;
+import com.andresv2.apirest.service.CategoryService;
+import jakarta.validation.Valid;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.List;
+
+@RestController
+@RequestMapping("v1/category")
+public class CategoryController {
+
+    @Autowired
+    private CategoryService categoryService;
+    @Autowired
+    private ProductRepository productRepo;
+
+    @PostMapping("register")
+    public ResponseEntity<Category> insertCategory(@Valid @RequestBody Category category){
+        return ResponseEntity.ok().body(categoryService.saveCategory(category));
+    }
+
+    @PostMapping("update")
+    public ResponseEntity<Category> updateCategory(@Valid @RequestBody Category category){
+        return ResponseEntity.ok().body(categoryService.saveCategory(category));
+    }
+
+    @GetMapping("id/{id}")
+    public ResponseEntity<Category> findCategoryById(@PathVariable("id") Long id){
+        return ResponseEntity.ok().body(categoryService.findCategoryById(id));
+    }
+
+    @GetMapping("list")
+    public ResponseEntity<List<Category>> findCategoriesList(@RequestParam(value = "page", required = false) Integer page, @RequestParam(value = "size", required = false) Integer size){
+        Pageable pageable = PageRequest.of(page!=null?page:0, size!=null?size:10, Sort.by("id").descending());
+        return ResponseEntity.ok().body(categoryService.findAllCategories(pageable).getContent());
+    }
+
+    @GetMapping("list/filtered")
+    public ResponseEntity<List<Category>> findCategoriesListFiltered(@RequestParam(value = "page", required = false) Integer page, @RequestParam(value = "size", required = false) Integer size, @RequestBody HashMap<String, Object> data){
+        Pageable pageable = PageRequest.of(page!=null?page:0, size!=null?size:10, Sort.by("id").descending());
+        return ResponseEntity.ok().body(categoryService.findAllFilteredCategories(pageable, new JSONObject(data)).getContent());
+    }
+
+    @PostMapping("{categoryId}/add/products")
+    public ResponseEntity<JSONObject> addProductToCategory(@PathVariable("categoryId") Long categoryId, @RequestBody HashMap<String, Object> data){
+        return ResponseEntity.ok().body(categoryService.addProductToCategory(categoryId, new JSONObject(data)));
+    }
+}

--- a/src/main/java/com/andresv2/apirest/controller/ProductController.java
+++ b/src/main/java/com/andresv2/apirest/controller/ProductController.java
@@ -1,7 +1,6 @@
 package com.andresv2.apirest.controller;
 
 import com.andresv2.apirest.entities.Product;
-import com.andresv2.apirest.entities.Store;
 import com.andresv2.apirest.service.ProductService;
 import jakarta.validation.Valid;
 import org.json.JSONObject;

--- a/src/main/java/com/andresv2/apirest/controller/StoreController.java
+++ b/src/main/java/com/andresv2/apirest/controller/StoreController.java
@@ -49,30 +49,4 @@ public class StoreController {
         return ResponseEntity.ok().body(storeService.findAllFilteredStores(pageable, new JSONObject(data)).getContent());
     }
 
-    @PostMapping("category/register")
-    public ResponseEntity<Category> insertCategory(@Valid @RequestBody Category category){
-        return ResponseEntity.ok().body(storeService.saveCategory(category));
-    }
-
-    @PostMapping("category/update")
-    public ResponseEntity<Category> updateCategory(@Valid @RequestBody Category category){
-        return ResponseEntity.ok().body(storeService.saveCategory(category));
-    }
-
-    @GetMapping("category/id/{id}")
-    public ResponseEntity<Category> findCategoryById(@PathVariable("id") Long id){
-        return ResponseEntity.ok().body(storeService.findCategoryById(id));
-    }
-
-    @GetMapping("category/list")
-    public ResponseEntity<List<Category>> findCategoriesList(@RequestParam(value = "page", required = false) Integer page, @RequestParam(value = "size", required = false) Integer size){
-        Pageable pageable = PageRequest.of(page!=null?page:0, size!=null?size:10, Sort.by("id").descending());
-        return ResponseEntity.ok().body(storeService.findAllCategories(pageable).getContent());
-    }
-
-    @GetMapping("category/list/filtered")
-    public ResponseEntity<List<Category>> findCategoriesListFiltered(@RequestParam(value = "page", required = false) Integer page, @RequestParam(value = "size", required = false) Integer size, @RequestBody HashMap<String, Object> data){
-        Pageable pageable = PageRequest.of(page!=null?page:0, size!=null?size:10, Sort.by("id").descending());
-        return ResponseEntity.ok().body(storeService.findAllFilteredCategories(pageable, new JSONObject(data)).getContent());
-    }
 }

--- a/src/main/java/com/andresv2/apirest/entities/Category.java
+++ b/src/main/java/com/andresv2/apirest/entities/Category.java
@@ -24,8 +24,6 @@ public class Category {
     private String name;
     private String description;
     @Transient
-    private List<Store> stores;
-    @Transient
     private List<Product> products;
     @Transient
     private String error;

--- a/src/main/java/com/andresv2/apirest/entities/Product.java
+++ b/src/main/java/com/andresv2/apirest/entities/Product.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+
 @Entity
 @Data
 @NoArgsConstructor
@@ -21,10 +22,11 @@ public class Product {
     private Long id;
     private String name;
     private String description;
+    private String genre;
     private Double price;
     private Boolean discount;
     private String image;
-    private Integer category_id;
+    private String category;
     private Integer stock;
     private Boolean active;
 }

--- a/src/main/java/com/andresv2/apirest/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/andresv2/apirest/exception/CustomExceptionHandler.java
@@ -1,7 +1,6 @@
 package com.andresv2.apirest.exception;
 
 import com.andresv2.apirest.dto.ErrorResponseDto;
-import com.andresv2.apirest.service.UserService;
 import com.auth0.jwt.exceptions.TokenExpiredException;
 import com.mysql.cj.jdbc.exceptions.MysqlDataTruncation;
 import org.slf4j.Logger;

--- a/src/main/java/com/andresv2/apirest/repository/CategoryRepository.java
+++ b/src/main/java/com/andresv2/apirest/repository/CategoryRepository.java
@@ -1,13 +1,17 @@
 package com.andresv2.apirest.repository;
 
 import com.andresv2.apirest.entities.Category;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, Long>, JpaSpecificationExecutor<Category> {
+
+    @Query(value = "select * from category c left join store_categories sc on(sc.category_id = c.id) where sc.store_id = ?1", nativeQuery = true)
+    List<Category> getCategoriesByStoreId(Long storeId);
 }

--- a/src/main/java/com/andresv2/apirest/repository/ProductRepository.java
+++ b/src/main/java/com/andresv2/apirest/repository/ProductRepository.java
@@ -3,8 +3,15 @@ package com.andresv2.apirest.repository;
 import com.andresv2.apirest.entities.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface ProductRepository extends JpaRepository<Product, Long>, JpaSpecificationExecutor<Product> {
+
+    @Query(value = "select p.* from product p inner join category c on(p.category = c.name) where c.name = ?1", nativeQuery = true)
+    List<Product> findAllByCategory(String name);
 }

--- a/src/main/java/com/andresv2/apirest/repository/StoreRepository.java
+++ b/src/main/java/com/andresv2/apirest/repository/StoreRepository.java
@@ -6,7 +6,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
 
 @Repository
 public interface StoreRepository extends JpaRepository<Store, Long>, JpaSpecificationExecutor<Store> {

--- a/src/main/java/com/andresv2/apirest/repository/UserRepository.java
+++ b/src/main/java/com/andresv2/apirest/repository/UserRepository.java
@@ -1,9 +1,6 @@
 package com.andresv2.apirest.repository;
 
 import com.andresv2.apirest.entities.User;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/com/andresv2/apirest/service/CategoryService.java
+++ b/src/main/java/com/andresv2/apirest/service/CategoryService.java
@@ -1,6 +1,7 @@
 package com.andresv2.apirest.service;
 
-import com.andresv2.apirest.entities.Product;
+import com.andresv2.apirest.entities.Category;
+import com.andresv2.apirest.repository.CategoryRepository;
 import com.andresv2.apirest.repository.ProductRepository;
 import com.andresv2.apirest.util.SearchUtils;
 import org.json.JSONObject;
@@ -9,35 +10,40 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
-public class ProductService {
+public class CategoryService {
 
     @Autowired
-    private ProductRepository productRepo;
+    private CategoryRepository categoryRepo;
     @Autowired
-    private SearchUtils<Product> searchUtilsProduct;
+    private ProductRepository  productRepo;
+    @Autowired
+    private SearchUtils<Category> searchUtilsCategory;
 
-    public Product saveProduct(Product product) {
-        return productRepo.save(product);
+    public Category saveCategory(Category category) {
+        return categoryRepo.save(category);
     }
 
-    public Product findProductById(Long id) {
-        return productRepo.findById(id).get();
+    public Category findCategoryById(Long id) {
+        Category category = categoryRepo.findById(id).orElseThrow(() -> new RuntimeException("Store not found"));
+
+        category.setProducts(productRepo.findAllByCategory(category.getName()));
+        return category;
     }
 
-    public Page<Product> findAllProducts(Pageable pageable) {
-        return productRepo.findAll(pageable);
+    public Page<Category> findAllCategories(Pageable pageable) {
+        return categoryRepo.findAll(pageable);
     }
 
-    public Page<Product> findAllFilteredProducts(Pageable pageable, JSONObject data) {
+    public Page<Category> findAllFilteredCategories(Pageable pageable, JSONObject data) {
         JSONObject filters = new JSONObject();
         JSONObject equalsTo = new JSONObject();
 //        JSONObject between = new JSONObject(); //only if filters have between option
         // Define Filters
         if (data.has("name")) equalsTo.put("name", data.getString("name"));
         if (data.has("description")) equalsTo.put("description", data.getString("description"));
-        if (data.has("ramo")) equalsTo.put("ramo", data.getString("ramo"));
-        if (data.has("category")) equalsTo.put("category", data.getString("category"));
 
         if(equalsTo.length() > 0) filters.put("equals", equalsTo);
 //        if(between.length() > 0) filters.put("between", between); //only if filters have between option
@@ -45,8 +51,10 @@ public class ProductService {
         // if the method have more filters like between or  greater than etc. we need to add the summary of sizes to size key Example size-> filters.put("size", equalsTo.length() + greaterThan.length() + between.length());
         filters.put("size", equalsTo.length()); // + between.length()
 
-        return productRepo.findAll(searchUtilsProduct.getQueryParameters(filters), pageable);
+        return categoryRepo.findAll(searchUtilsCategory.getQueryParameters(filters), pageable);
     }
 
-
+    public List<Category> getCategoriesByStoreId(Long storeId) {
+        return categoryRepo.getCategoriesByStoreId(storeId); //return the categories of the store by storeId
+    }
 }

--- a/src/main/java/com/andresv2/apirest/service/StoreService.java
+++ b/src/main/java/com/andresv2/apirest/service/StoreService.java
@@ -17,18 +17,20 @@ public class StoreService {
     @Autowired
     private StoreRepository storeRepo;
     @Autowired
-    private CategoryRepository categoryRepo;
-    @Autowired
     private SearchUtils<Store> searchUtilsStore;
     @Autowired
-    private SearchUtils<Category> searchUtilsCategory;
+    private CategoryService categoryService;
 
     public Store saveStore(Store store) {
         return storeRepo.save(store);
     }
 
     public Store findStoreById(Long id) {
-        return storeRepo.findById(id).get();
+        // Use A separated consult 'cause we need only in this case search the categories of a store but on a list
+        Store store = storeRepo.findById(id).orElseThrow(() -> new RuntimeException("Store not found"));
+
+        store.setCategories(categoryService.getCategoriesByStoreId(id));
+        return store;
     }
 
     public Page<Store> findAllStores(Pageable pageable) {
@@ -52,34 +54,5 @@ public class StoreService {
         filters.put("size", equalsTo.length()); // + between.length()
 
         return storeRepo.findAll(searchUtilsStore.getQueryParameters(filters), pageable);
-    }
-
-    public Category saveCategory(Category category) {
-        return categoryRepo.save(category);
-    }
-
-    public Category findCategoryById(Long id) {
-        return categoryRepo.findById(id).get();
-    }
-
-    public Page<Category> findAllCategories(Pageable pageable) {
-        return categoryRepo.findAll(pageable);
-    }
-
-    public Page<Category> findAllFilteredCategories(Pageable pageable, JSONObject data) {
-        JSONObject filters = new JSONObject();
-        JSONObject equalsTo = new JSONObject();
-//        JSONObject between = new JSONObject(); //only if filters have between option
-        // Define Filters
-        if (data.has("name")) equalsTo.put("name", data.getString("name"));
-        if (data.has("description")) equalsTo.put("description", data.getString("description"));
-
-        if(equalsTo.length() > 0) filters.put("equals", equalsTo);
-//        if(between.length() > 0) filters.put("between", between); //only if filters have between option
-
-        // if the method have more filters like between or  greater than etc. we need to add the summary of sizes to size key Example size-> filters.put("size", equalsTo.length() + greaterThan.length() + between.length());
-        filters.put("size", equalsTo.length()); // + between.length()
-
-        return categoryRepo.findAll(searchUtilsCategory.getQueryParameters(filters), pageable);
     }
 }

--- a/src/main/java/com/andresv2/apirest/util/SearchUtils.java
+++ b/src/main/java/com/andresv2/apirest/util/SearchUtils.java
@@ -1,7 +1,6 @@
 package com.andresv2.apirest.util;
 
 import jakarta.persistence.criteria.Predicate;
-import lombok.experimental.UtilityClass;
 import org.json.JSONObject;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;


### PR DESCRIPTION
- Remove Jpa Relations 'cause on list some entity this was returning all the data with relations, example if we call the /store/list this was returning all categories and products, and this is wrong, because this has to return only the list of stores, but when use /store/id/{id} you have to return all categories related
- ADD Category Controller and Service
- Move all Category endpoints to Category Controller
- Move all Category Methods to Category Service